### PR TITLE
BTree-based component registries and site managers.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,3 +12,5 @@
   performance regression in large sites. If so we'll find a different
   way to deal with it.
 - Remove HostSitesFolder._delitemf. It was unused and buggy.
+- Add BTreesLocalSiteManager to automatically switch internal
+  registration data to BTrees when possible and necessary. See issue #4.

--- a/src/nti/site/folder.py
+++ b/src/nti/site/folder.py
@@ -13,7 +13,7 @@ from zope import interface
 
 from zope.site.folder import Folder
 
-from zope.site.site import LocalSiteManager as _ZLocalSiteManager
+from .site import BTreeLocalSiteManager
 
 from ZODB.POSException import ConnectionStateError
 
@@ -47,7 +47,7 @@ class HostPolicyFolder(Folder):
         return 'HostPolicyFolder(%s,%s)' % (self.__name__, id(self))
 
 @interface.implementer(IHostPolicySiteManager)
-class HostPolicySiteManager(_ZLocalSiteManager):
+class HostPolicySiteManager(BTreeLocalSiteManager):
 
     def __repr__(self):
         try:

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -3,8 +3,9 @@
 """
 .. $Id$
 """
+# NOTE: unicode_literals is NOT imported!!
+from __future__ import print_function, absolute_import, division
 
-from __future__ import print_function, unicode_literals, absolute_import, division
 __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
@@ -60,7 +61,7 @@ def get_site_for_site_names(site_names, site=None):
         # Do we have a persistent site installed in the database? If yes,
         # we want to use that.
         try:
-            pers_site = site['++etc++hostsites'][site_name]
+            pers_site = site[u'++etc++hostsites'][site_name]
             site = pers_site
         except (KeyError, TypeError):
             # No, nothing persistent, dummy one up.
@@ -137,6 +138,8 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
     A persistent adapter registry that can switch its internal
     data structures to be more persistent friendly when they get large.
     """
+    # Inherit from _LocalAdapterRegistry for maximum compatibility...we are
+    # going to swizzle out classes. Also, it makes sure we are ILocation.
 
     # Interestingly, we are totally fine to switch out the type from dict
     # to BTree. Much of the actual lookup code is implemented in C, but it calls
@@ -153,9 +156,20 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
         for i in range(len(byorder)):
             mapping = byorder[i]
             if not isinstance(mapping, btree_type) and len(mapping) > self.btree_map_threshold:
-                mapping = btree_type(mapping)
-                byorder[i] = mapping
-                self._p_changed = True
+                try:
+                    mapping = btree_type(mapping)
+                except TypeError:
+                    # There must be something registered on a class
+                    # in this map: implementedBy has default comparison and can't
+                    # be stored in a btree. Checking data in the wild doesn't
+                    # show any such adapter registrations (most common place for them)
+                    # but be safe and ignore it. Log it so we know if it does come up,
+                    # and can work out a better plan to handle performance issues due to the
+                    # failed conversion.
+                    logger.exception("Failed to convert registry to adapters")
+                else:
+                    byorder[i] = mapping
+                    self._p_changed = True
 
             # This is the first level of the decision tree, and thus
             # the least discriminatory. If i is 0, then this is only
@@ -163,9 +177,15 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
             # (Which is the most common in some usages). These maps are thus
             # liable to get to be the biggest. Note that we only replace at this
             # level.
-            replacement_vals = {k: btree_type(v)
-                                for k, v in mapping.items()
-                                if not isinstance(v, btree_type) and len(v) > self.btree_map_threshold}
+            replacement_vals = {}
+            for k, v in mapping.items():
+                if not isinstance(v, btree_type) and len(v) > self.btree_map_threshold:
+                    try:
+                        replacement_vals[k] = btree_type(v)
+                    except TypeError: # pragma: no cover
+                        # See above.
+                        logger.exception("Failed to convert nested registry to adapters")
+
             if replacement_vals:
                 mapping.update(replacement_vals)
                 self._p_changed = True
@@ -183,12 +203,22 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
 class BTreePersistentComponents(PersistentComponents):
     """
     Persistent components that will be friendly to ZODB when they get large.
+
+    Note that despite the name, this class is not Persistent, only its
+    internal components are.
     """
 
     btree_family = family64
     btree_threshold = 5000
 
     def _init_registries(self):
+        # NOTE: We cannot simply replace these two attributes at runtime
+        # or even in a migration (for example, to upgrade from one type to another type)
+        # and expect it to work. If we are the base of some other Components
+        # or SiteManager, then these attributes have been copied into the __bases__
+        # of *its* adapters and utilities. If we swap out our ivar, then the bases
+        # will be out of sync and lookup will be broken. (BTreeLocalSiteManager
+        # supposedly keeps track of its subs and so it *could* swap out all of them too.)
         self.adapters = BTreeLocalAdapterRegistry()
         self.utilities = BTreeLocalAdapterRegistry()
         self.adapters.__parent__ = self.utilities.__parent__ = self
@@ -201,11 +231,13 @@ class BTreePersistentComponents(PersistentComponents):
         if not isinstance(mapping, btree_type) and len(mapping) > self.btree_threshold:
             mapping = btree_type(mapping)
             setattr(self, mapping_name, mapping)
-            self._p_changed = True
+            # NOTE: This class is *NOT* Persistent, but its subclass BTreeLocalSiteManager
+            # *is*. That's why __setstate__ is there and not here...it doesn't make much sense here.
 
     def registerUtility(self, *args, **kwargs):
         result = super(BTreePersistentComponents, self).registerUtility(*args, **kwargs)
         self._check_and_btree_map('_utility_registrations')
+
         return result
 
     def registerAdapter(self, *args, **kwargs):
@@ -218,6 +250,29 @@ class BTreeLocalSiteManager(BTreePersistentComponents, LocalSiteManager):
     Persistent local site manager that will be friendly to ZODB when they
     get large.
     """
+
+    def __setstate__(self, state):
+        super(BTreeLocalSiteManager, self).__setstate__(state)
+        # Graceful migration from older versions of this class.
+        # See note in _init_registries for why we can't simply swap these to new
+        # ivars. Instead, we adjust their __class__. Note that we'll have to keep doing this
+        # forever or until we save a brand new copy of the object, because the class is stored
+        # as part of the pickle. Adjusting the class works because we know that the layout
+        # is exactly the same. Now, other objects could be awake and active and querying
+        # this object under its old class through their own __bases__, but that's ok:
+        # our behaviour modification only comes in at write time...which only happens
+        # through methods we expose, so we'll get a chance to swizzle the object out.
+        for reg in self.adapters, self.utilities:
+            if (not isinstance(reg, BTreeLocalAdapterRegistry)
+                and isinstance(reg, _LocalAdapterRegistry)):
+                # Only do this for classes we know about.
+                # Note: In Persistent 4.2.1, pure-python and C handle __class__ differently.
+                # Pure-python doesn't set _p_changed, but C does.
+                changed = reg._p_changed
+                reg.__class__ = BTreeLocalAdapterRegistry
+                if not changed:
+                    reg._p_changed = False
+
 
 # Legacy notes:
 # Opening the connection registered it with the transaction manager as an ISynchronizer.

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -26,10 +26,7 @@ from nti.site.transient import TrivialSite
 from nti.site.transient import HostSiteManager
 
 _PYPY = hasattr(sys, 'pypy_version_info')
-if _PYPY:
-    _DEFAULT_COMPARISON = "Can't use default __cmp__"
-else:
-    _DEFAULT_COMPARISON = "Object has default comparison"
+_DEFAULT_COMPARISON = "Can't use default __cmp__" if _PYPY else "Object has default comparison"
 
 def find_site_components(site_names):
     """

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -193,7 +193,8 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
     def changed(self, originally_changed):
         # If we changed, check and migrate
         if originally_changed is self:
-            if len(self._provided) > self.btree_provided_threshold:
+            if (not isinstance(self._provided, self.btree_family.OI.BTree)
+                and len(self._provided) > self.btree_provided_threshold):
                 self._provided = self.btree_family.OI.BTree(self._provided)
                 self._p_changed = True
             for byorder in self._adapters, self._subscribers:

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -180,6 +180,9 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
                     logger.exception("Failed to convert registry to BTree in %s", self.__name__)
                 else:
                     byorder[i] = mapping
+                    # self._adapters and self._subscribers are both simply
+                    # of type `list` (not persistent list) so when we make changes
+                    # to them, we need to set self._p_changed
                     self._p_changed = True
 
             # This is the first level of the decision tree, and thus
@@ -199,7 +202,8 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
 
             if replacement_vals:
                 mapping.update(replacement_vals)
-                self._p_changed = True
+                if not isinstance(mapping, btree_type):
+                    self._p_changed = True
 
     def changed(self, originally_changed):
         # If we changed, check and migrate

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -210,8 +210,10 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
 
             if replacement_vals:
                 mapping.update(replacement_vals)
-                if not isinstance(mapping, btree_type):
-                    self._p_changed = True
+                # This is a btree now, so there's no need to mark
+                # self as _p_changed when we change it.
+                assert isinstance(mapping, btree_type)
+
 
     def register(self, required, provided, name, value):
         """

--- a/src/nti/site/tests/test_localutility.py
+++ b/src/nti/site/tests/test_localutility.py
@@ -32,7 +32,7 @@ from zope.interface import Interface
 from zope import interface
 
 from zope.component.interfaces import ISite
-from zope.site import LocalSiteManager
+from ..site import BTreeLocalSiteManager as LocalSiteManager
 from zope.site import SiteManagerContainer
 from zope.container.contained import Contained
 from zope.location.interfaces import ILocationInfo

--- a/src/nti/site/tests/test_site.py
+++ b/src/nti/site/tests/test_site.py
@@ -23,6 +23,7 @@ import unittest
 from zope import interface
 
 from zope.interface import ro
+from zope.interface import implementedBy
 from zope.interface import Interface
 
 from zope.component.hooks import getSite
@@ -47,7 +48,6 @@ from ..site import get_component_hierarchy_names
 from nti.site.tests import SharedConfiguringTestLayer
 
 from nti.testing.matchers import validly_provides
-from nti.testing.matchers import is_true
 from nti.testing.matchers import is_false
 from nti.testing.base import AbstractTestBase
 
@@ -202,10 +202,12 @@ class TestGetComponentHierarchy(AbstractTestBase):
 from ..site import BTreeLocalSiteManager as BLSM
 from ..site import _LocalAdapterRegistry
 from ..site import BTreeLocalAdapterRegistry
+from ..site import _DEFAULT_COMPARISON
 import sys
-PYPY = hasattr(sys, 'pypy_version_info')
+
 from ZODB import DB
 from ZODB.DemoStorage import DemoStorage
+import transaction
 
 import pickle
 try:
@@ -241,8 +243,7 @@ class TestBTreeSiteMan(AbstractTestBase):
             assert_that(new_sub.utilities.__bases__[0], is_(BTreeLocalAdapterRegistry))
 
 
-    def test_pickle_setstate_swap_class_zodb(self):
-        storage = DemoStorage()
+    def _store_base_subs_in_zodb(self, storage):
         db = DB(storage)
         conn = db.open()
 
@@ -264,10 +265,15 @@ class TestBTreeSiteMan(AbstractTestBase):
         conn.root()['base'] = base_comps
         conn.root()['sub'] = sub_comps
 
-        import transaction
+
         transaction.commit()
         conn.close()
         db.close()
+
+    def test_pickle_setstate_swap_class_zodb(self):
+        storage = DemoStorage()
+
+        self._store_base_subs_in_zodb(storage)
 
         db = DB(storage)
         conn = db.open()
@@ -309,8 +315,18 @@ class TestBTreeSiteMan(AbstractTestBase):
         assert_that(new_sub.adapters.__bases__[0],
                     has_property('_p_changed', is_false()))
 
+    def test_pickle_zodb_lookup_adapter(self):
         # Now, we can register a couple adapters in the base, save everything,
         # and look it up in the sub (when the classes don't match)
+        storage = DemoStorage()
+        self._store_base_subs_in_zodb(storage)
+
+        db = DB(storage)
+        conn = db.open()
+        new_base = conn.root()['base']
+        new_base._p_activate()
+        new_sub = conn.root()['sub']
+
 
         new_base.adapters.btree_provided_threshold = 0
         new_base.adapters.btree_map_threshold = 0
@@ -327,11 +343,18 @@ class TestBTreeSiteMan(AbstractTestBase):
                                  required=(IFoo,),
                                  provided=IMock)
         provided2 = new_base.adapters._provided
+        # Make sure that it only converted once
+        assert_that(provided1, is_(same_instance(provided2)))
         assert_that(new_base._adapter_registrations, is_(BTrees.OOBTree.OOBTree))
+        assert_that(new_base._adapter_registrations.keys(),
+                    contains(
+                        ((IFoo,), IMock, u''),
+                        ((implementedBy(object),), IFoo, u''),
+                    ))
         assert_that(new_base.adapters._provided, is_(BTrees.family64.OI.BTree))
         assert_that(new_base.adapters._adapters[0], is_({}))
         assert_that(new_base.adapters._adapters[1][IFoo], is_(BTrees.family64.OO.BTree))
-        assert_that(provided1, is_(same_instance(provided2)))
+
 
         transaction.commit()
         conn.close()
@@ -344,9 +367,109 @@ class TestBTreeSiteMan(AbstractTestBase):
         x = new_sub.queryAdapter(self, IFoo)
         assert_that(x, is_(1))
 
-
         x = new_sub.queryAdapter(RootFoo(), IMock)
         assert_that(x, is_(2))
+
+    def test_pickle_zodb_lookup_utility(self):
+        # Now, we can register a couple utilities in the base, save everything,
+        # and look it up in the sub (when the classes don't match)
+        storage = DemoStorage()
+        self._store_base_subs_in_zodb(storage)
+
+        db = DB(storage)
+        conn = db.open()
+        new_base = conn.root()['base']
+        new_base._p_activate()
+        new_sub = conn.root()['sub']
+
+
+        new_base.utilities.btree_provided_threshold = 0
+        new_base.utilities.btree_map_threshold = 0
+
+        new_base.registerUtility(MockSite(),
+                                 provided=IFoo)
+        provided1 = new_base.adapters._provided
+        try:
+            new_base.registerUtility(MockSite(),
+                                     provided=implementedBy(object),
+                                     name=u'foo')
+            self.fail("Should raise TypeError")
+        except TypeError as e:
+            # Once we've converted, we can't register implementedBy
+            # again.
+            assert_that(e.args[0], is_(_DEFAULT_COMPARISON))
+
+        new_base.registerUtility(MockSite(),
+                                 provided=IMock,
+                                 name=u'foo')
+
+        provided2 = new_base.adapters._provided
+        # Make sure that it only converted once
+        assert_that(provided1, is_(same_instance(provided2)))
+        assert_that(new_base._utility_registrations, is_(BTrees.OOBTree.OOBTree))
+        assert_that(new_base._utility_registrations.keys(),
+                    contains(
+                        ((IFoo, u'')),
+                        (IMock, u'foo'),
+                    ))
+        assert_that(new_base.utilities._provided, is_(BTrees.family64.OI.BTree))
+        assert_that(new_base.utilities._adapters[0], is_(BTrees.family64.OO.BTree))
+
+        assert_that(new_base.utilities._adapters[0][IFoo], is_(BTrees.family64.OO.BTree))
+
+
+        transaction.commit()
+        conn.close()
+        db.close()
+
+        db = DB(storage)
+        conn = db.open()
+        new_sub = conn.root()['sub']
+
+        x = new_sub.queryUtility(IFoo)
+        assert_that(x, is_(MockSite))
+
+        x = new_sub.queryUtility(IMock, u'foo')
+        assert_that(x, is_(MockSite))
+
+
+    def test_convert_with_utility_registered_on_class(self):
+        comps = BLSM(None)
+
+        comps.utilities.btree_provided_threshold = 0
+        comps.utilities.btree_map_threshold = 0
+
+        comps.registerUtility(MockSite(),
+                              provided=implementedBy(object),
+                              name=u'foo')
+        assert_that(comps.utilities._provided, is_(dict))
+
+        # But you can't easily query for these so it shouldn't
+        # matter.
+        x = comps.queryUtility(implementedBy(object), u'foo')
+        assert_that(x, is_(none()))
+        x = comps.queryUtility(object, u'foo')
+        assert_that(x, is_(none()))
+
+        x = comps.queryUtility(Interface, u'foo')
+        assert_that(x, is_(MockSite))
+
+
+    def test_convert_with_utility_no_provided(self):
+        comps = BLSM(None)
+
+        comps.utilities.btree_provided_threshold = 0
+        comps.utilities.btree_map_threshold = 0
+
+        class AUtility(object):
+            # Doesn't implement any interfaces
+            pass
+
+        # You can't easily register them this way anyway
+        assert_that(calling(comps.registerUtility).with_args(AUtility()),
+        raises(TypeError, "The utility doesn't provide a single interface"))
+
+
 
 def _foo_factory(o):
     return 1

--- a/src/nti/site/tests/test_site.py
+++ b/src/nti/site/tests/test_site.py
@@ -322,14 +322,16 @@ class TestBTreeSiteMan(AbstractTestBase):
         new_base.registerAdapter(_foo_factory,
                                  required=(object,),
                                  provided=IFoo)
+        provided1 = new_base.adapters._provided
         new_base.registerAdapter(_foo_factory2,
                                  required=(IFoo,),
                                  provided=IMock)
+        provided2 = new_base.adapters._provided
         assert_that(new_base._adapter_registrations, is_(BTrees.OOBTree.OOBTree))
         assert_that(new_base.adapters._provided, is_(BTrees.family64.OI.BTree))
         assert_that(new_base.adapters._adapters[0], is_({}))
         assert_that(new_base.adapters._adapters[1][IFoo], is_(BTrees.family64.OO.BTree))
-
+        assert_that(provided1, is_(same_instance(provided2)))
 
         transaction.commit()
         conn.close()


### PR DESCRIPTION
This implementation leaves small maps alone, only going to the more expensive BTree at a configurable threshold. The cutoffs I picked are pretty random and can be adjusted.

Existing large objects should be migrated in place on their first write (when we'd be serializing them again anyway).