### PR TITLE
Add a new IClientSite interface to denote sites where some actions wi…

### DIFF
--- a/src/nti/site/folder.py
+++ b/src/nti/site/folder.py
@@ -11,7 +11,12 @@ __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
 
+from zope import component
 from zope import interface
+
+from zope.securitypolicy.interfaces import IPrincipalRoleManager
+
+from zope.securitypolicy.principalrole import AnnotationPrincipalRoleManager
 
 from zope.site.folder import Folder
 
@@ -56,3 +61,9 @@ class HostPolicySiteManager(BTreeLocalSiteManager):
             return super(HostPolicySiteManager, self).__repr__()
         except ConnectionStateError:
             return object.__repr__(self)
+
+
+@component.adapter(IHostPolicyFolder)
+@interface.implementer(IPrincipalRoleManager)
+class SitePrincipalRoleManager(AnnotationPrincipalRoleManager):
+    pass

--- a/src/nti/site/folder.py
+++ b/src/nti/site/folder.py
@@ -11,12 +11,7 @@ __docformat__ = "restructuredtext en"
 
 logger = __import__('logging').getLogger(__name__)
 
-from zope import component
 from zope import interface
-
-from zope.securitypolicy.interfaces import IPrincipalRoleManager
-
-from zope.securitypolicy.principalrole import AnnotationPrincipalRoleManager
 
 from zope.site.folder import Folder
 
@@ -61,9 +56,3 @@ class HostPolicySiteManager(BTreeLocalSiteManager):
             return super(HostPolicySiteManager, self).__repr__()
         except ConnectionStateError:
             return object.__repr__(self)
-
-
-@component.adapter(IHostPolicyFolder)
-@interface.implementer(IPrincipalRoleManager)
-class SitePrincipalRoleManager(AnnotationPrincipalRoleManager):
-    pass

--- a/src/nti/site/hostpolicy.py
+++ b/src/nti/site/hostpolicy.py
@@ -123,12 +123,12 @@ def synchronize_host_policies():
                 logger.info("Installing site policy %s", name)
 
                 site = HostPolicyFolder()
-                # should fire object created event
-                sites[name] = site
                 # Some comps are marked a certain way, we want to apply this
                 # to the site itself.
                 if IClientSite.providedBy(comps):
                     interface.alsoProvides(site, IClientSite)
+                # should fire object created event
+                sites[name] = site
 
                 site_policy = HostPolicySiteManager(site)
                 site_policy.__bases__ = (comps, secondary_comps)

--- a/src/nti/site/hostpolicy.py
+++ b/src/nti/site/hostpolicy.py
@@ -11,13 +11,11 @@ This contains the main unique functionality for this package.
 from __future__ import print_function, unicode_literals, absolute_import, division
 __docformat__ = "restructuredtext en"
 
-logger = __import__('logging').getLogger(__name__)
-
 from six import string_types
 
-from zope import lifecycleevent
 from zope import component
 from zope import interface
+from zope import lifecycleevent
 
 from zope.component.hooks import site as current_site
 from zope.component.interfaces import IComponents
@@ -28,15 +26,19 @@ from zope.interface.interfaces import ComponentLookupError
 
 from zope.traversing.interfaces import IEtcNamespace
 
-
 from zope.site.folder import Folder
 from zope.site.folder import rootFolder
 
-from .folder import HostPolicyFolder
-from .folder import HostPolicySiteManager
-from .folder import HostSitesFolder
-from .interfaces import IMainApplicationFolder
-from .site import BTreeLocalSiteManager
+from nti.site.folder import HostSitesFolder
+from nti.site.folder import HostPolicyFolder
+from nti.site.folder import HostPolicySiteManager
+
+from nti.site.interfaces import IClientSite
+from nti.site.interfaces import IMainApplicationFolder
+
+from nti.site.site import BTreeLocalSiteManager
+
+logger = __import__('logging').getLogger(__name__)
 
 
 def synchronize_host_policies():
@@ -123,6 +125,10 @@ def synchronize_host_policies():
                 site = HostPolicyFolder()
                 # should fire object created event
                 sites[name] = site
+                # Some comps are marked a certain way, we want to apply this
+                # to the site itself.
+                if IClientSite.providedBy(comps):
+                    interface.alsoProvides(site, IClientSite)
 
                 site_policy = HostPolicySiteManager(site)
                 site_policy.__bases__ = (comps, secondary_comps)

--- a/src/nti/site/interfaces.py
+++ b/src/nti/site/interfaces.py
@@ -40,7 +40,6 @@ class SiteNotInstalledError(AssertionError):
     This is most often caused by not installing the zope.component hooks.
     """
 
-
 class IMainApplicationFolder(IFolder):
     """
     The folder representing the application. The set of persistent
@@ -79,6 +78,13 @@ class IHostSitesFolder(IFolder):
     lastSynchronized = Number(title=u"The timestamp at which this object was last synchronized .",
                               default=0.0)
     lastSynchronized.setTaggedValue('_ext_excluded_out', True)
+
+
+class IClientSite(interface.Interface):
+    """
+    A marker interface for sites that are intended to operate as nearly
+    standalone, self-contained sites.
+    """
 
 
 class ITransactionSiteNames(interface.Interface):


### PR DESCRIPTION
…th parent site are limited. In particular, we want site admins (granted a site admin role on the child site) to *not* be considered site admins of the parent site. There are other cases where this is not true. 

I'm not positive the name `IClientSite` is appropriate, but I couldn't think of anything better at this point.