### PR TITLE
Refactor tests/__init__.py to be based on new features in nti.testing 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,10 +2,18 @@
  Changes
 =========
 
-2.0.1 (unreleased)
+2.1.0 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Test changes: Depend on ``nti.testing`` 3.0 and refactor certain
+  internal test methods for improved isolation. The dependency on
+  ZODB is now >= 5.6.0.
+
+  Some internal, undocumented test attributes (``current_mock_db``, a
+  ZODB.DB, and ``current_transaction`` which was actually a ZODB
+  Connection) have been removed. The former is replaced with
+  ``nti.testing.zodb.ZODBLayer.db``, and there is no replacement for
+  the later.
 
 
 2.0.0 (2019-09-10)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 TESTS_REQUIRE = [
     'fudge',
-    'nti.testing',
+    'nti.testing >= 3.0.0',
     'pyhamcrest',
     'z3c.baseregistry',
     'zope.testrunner',
@@ -47,7 +47,9 @@ setup(
     tests_require=TESTS_REQUIRE,
     install_requires=[
         'BTrees >= 4.3.2',  # permissive get()
-        'ZODB',
+        # test dependencies have this at >= 5.6.0; for consistency,
+        # do the same in regular deps.
+        'ZODB >= 5.6.0',
         'nti.schema',
         'nti.transactions >= 3.0.0',
         'persistent',


### PR DESCRIPTION
The next step is to extract the useful bits into a public nti.site.testing package so we can stop repeating them so many times (here, same basic code in `mock_dataserver`, `nti.intids`, and `nti.datastructures`)