### PR TITLE
Add extensible versions of mock_db_trans, etc, to nti.site.testing.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,28 @@
 language: python
-sudo: false
-group: travis_latest
 python:
   - 2.7
+  - 3.5
   - 3.6
   - 3.7
+  - 3.8
   - pypy
   - pypy3
 script:
   - coverage run -m zope.testrunner --test-path=src  --auto-color --auto-progress
+env:
+    global:
+        - PYTHONHASHSEED=1042466059
+
 after_success:
-  - coverage report
   - coveralls
 notifications:
   email: dev-regression-tests@nextthought.com
 
 install:
-  - pip install -U pip
-  - pip install -U setuptools
+  - pip install -U pip setuptools
   - pip install -U coveralls coverage
   - pip install -U -e ".[test]"
+
 
 cache: pip
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,15 @@
   ``nti.testing.zodb.ZODBLayer.db``, and there is no replacement for
   the later.
 
+- Add the module ``nti.site.testing``. This contains extensible,
+  documnted versions of the functions that were previously in
+  ``nti.site.tests`` as private helpers.
+
+- Add support for Python 3.8.
+
+- Make ``hostpolicy.install_main_application_and_sites()`` set the
+  *root_alias* correctly. Previously, instead of setting it to the
+  *root_name*, it set it to the *main_name*.
 
 2.0.0 (2019-09-10)
 ==================

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -97,7 +97,7 @@ exclude_patterns = ['_build']
 # The reST default role (used for this markup: `text`) to use for all
 # documents.
 #
-# default_role = None
+default_role = 'obj'
 
 # If true, '()' will be appended to :func: etc. cross-reference text.
 #
@@ -355,10 +355,12 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'https://docs.python.org/': None,
-    'http://zodb.readthedocs.io/en/latest/': None,
-    'http://zopeinterface.readthedocs.io/en/latest/': None,
-    'http://zopecomponent.readthedocs.io/en/latest/': None,
-    'http://zopesite.readthedocs.io/en/latest/': None,
+    'https://zodb-docs.readthedocs.io/en/latest/': None,
+    'https://zopeinterface.readthedocs.io/en/latest/': None,
+    'https://zopecomponent.readthedocs.io/en/latest/': None,
+    'https://zopesite.readthedocs.io/en/latest/': None,
+    'https://zopetraversing.readthedocs.io/en/latest/': None,
+    'https://ntitesting.readthedocs.io/en/latest/': None,
 }
 
 extlinks = {'issue': ('https://github.com/NextThought/nti.site/issues/%s',

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,9 +6,13 @@
 Contents:
 
 .. toctree::
-   :maxdepth: 1
+   :maxdepth: 2
 
    nti.site
+
+.. toctree::
+   :maxdepth: 1
+
    changelog
 
 .. automodule:: nti.site

--- a/doc/nti.site.rst
+++ b/doc/nti.site.rst
@@ -12,3 +12,4 @@ nti.site package
    nti.site.subscribers
    nti.site.transient
    nti.site.utils
+   nti.site.testing

--- a/doc/nti.site.rst
+++ b/doc/nti.site.rst
@@ -1,5 +1,6 @@
-nti.site package
-================
+========================
+ nti.site API Reference
+========================
 
 .. toctree::
 

--- a/doc/nti.site.testing.rst
+++ b/doc/nti.site.testing.rst
@@ -1,0 +1,7 @@
+=========================
+ nti.site.testing module
+=========================
+
+.. automodule:: nti.site.testing
+    :members:
+    :show-inheritance:

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ TESTS_REQUIRE = [
     'pyhamcrest',
     'z3c.baseregistry',
     'zope.testrunner',
+    'coverage',
 ]
 
 
@@ -36,6 +37,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],
@@ -70,6 +72,6 @@ setup(
             'Sphinx',
             'repoze.sphinx.autointerface',
             'sphinx_rtd_theme',
-        ]
+        ] + TESTS_REQUIRE # To be able to import nti.site.testing
     },
 )

--- a/src/nti/site/__init__.py
+++ b/src/nti/site/__init__.py
@@ -38,16 +38,16 @@ and contains any applicable policies that are globally configured.
   site configurations.
 * See :mod:`nti.site.site` for the getting the correctly configured site.
 * See :mod:`nti.site.subscribers` for setting up the correct site during traversal.
-
+* See :mod:`nti.site.testing` for test helpers.
 """
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 __docformat__ = "restructuredtext en"
 
-logger = __import__('logging').getLogger(__name__)
+# All of these imports are deprecated and will be removed in 2021.
 
-from nti.site.hostpolicy import get_host_site
-from nti.site.hostpolicy import get_all_host_sites
+from nti.site.hostpolicy import get_host_site # pylint:disable=unused-import
+from nti.site.hostpolicy import get_all_host_sites # pylint:disable=unused-import
 
-from nti.site.utils import registerUtility
-from nti.site.utils import unregisterUtility
+from nti.site.utils import registerUtility # pylint:disable=unused-import
+from nti.site.utils import unregisterUtility # pylint:disable=unused-import

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -137,6 +137,8 @@ def get_site_for_site_names(site_names, site=None):
             assert isinstance(site.getSiteManager(), Persistent)
 
             main_site = site
+            # XXX: This easily produces resolution orders that are
+            # inconsistent with C3. See test_site.test_no_persistent_site.
             site_manager = HostSiteManager(main_site.__parent__,
                                            main_site.__name__,
                                            site_components,

--- a/src/nti/site/testing.py
+++ b/src/nti/site/testing.py
@@ -1,0 +1,354 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Support for testing code that uses :mod:`nti.site`.
+
+Most of the functionality exposed through this module uses :mod:`ZODB`
+to test persistence and transaction handling and is based on the
+support code from :mod:`nti.testing.zodb`.
+
+.. versionadded:: 2.1.0
+"""
+from __future__ import print_function
+from __future__ import absolute_import
+from __future__ import division
+
+
+import unittest
+import functools
+
+from ZODB.DemoStorage import DemoStorage
+from hamcrest import assert_that
+
+from nti.testing import zodb
+from nti.testing.layers import ConfiguringLayerMixin
+from nti.testing.layers import GCLayerMixin
+from nti.testing.layers import find_test
+from nti.testing.matchers import provides
+
+from zope import component
+from zope.component.hooks import setHooks
+from zope.component.hooks import resetHooks
+from zope.component.hooks import site as currentSite
+from zope.site import SiteManagerContainer
+import ZODB
+import zope.testing.cleanup
+
+from .hostpolicy import install_main_application_and_sites
+from . import hostpolicy
+from .interfaces import IMainApplicationFolder
+from .site import BTreeLocalSiteManager
+from .site import get_site_for_site_names
+
+__all__ = [
+    'setHooks',
+    'resetHooks',
+    'print_tree',
+    'current_db_site_trans',
+    'SharedConfiguringTestLayer',
+    'SiteTestCase',
+    'uses_independent_db_site',
+]
+
+
+def print_tree(folder, depth=1, file=None, seen=None, name=None, basic_indent='    '):
+    """
+    print_tree(folder, file=sys.stdout, basic_indent='    ') -> None
+
+    Print a descriptive tree of the contents of the dict-like *folder* to *file*.
+    """
+    import sys
+    from zope.site.interfaces import IRootFolder
+    from zope.component.interfaces import ISite
+
+    file = file or sys.stdout
+    seen = seen if seen is not None else dict()
+    indent = basic_indent * depth
+
+    folder_id = id(folder)
+
+    if name is None:
+        name = getattr(folder, '__name__', None)
+        if not name:
+            if getattr(folder, '_p_jar', None) and folder._p_jar.root() is folder:
+                name = "<Connection Root Dictionary>"
+            else:
+                name = str(folder)
+
+    if folder_id in seen:
+        print(indent, name, '->', seen[folder_id], file=file)
+        return
+    seen[id(folder)] = name + ' ' + str(folder_id)
+
+    provs = []
+    for iface in ISite, IRootFolder, IMainApplicationFolder:
+        if iface.providedBy(folder):
+            provs.append(iface.__name__)
+    if provs:
+        name = '<' + ','.join(provs) + '>: ' + name
+
+    print(indent, name, folder_id, type(folder), file=file)
+
+    if hasattr(folder, 'items'):
+        for k, v in sorted(folder.items()):
+            print_tree(v, depth + 1, file, seen, k)
+    else:
+        print(basic_indent * (depth + 1), repr(folder), file=file)
+
+
+class current_db_site_trans(zodb.mock_db_trans):
+    """
+    Context manager for a ZODB database connection and
+    active ``zope.component`` site.
+
+    .. versionchanged:: 2.1.0
+       While there was no previous public version of this class,
+       there was a private version in ``nti.site.tests``. That version
+       called :func:`.install_main_application_and_sites` setting
+       the *root_alias* to the :attr:`main_application_folder_name`.
+       Since older versions of that function installed the *root_alias* to point
+       to the *main_name*, this used result in no alias for the root folder in the
+       root. Now, there will be an alias (at :obj:`~.DEFAULT_ROOT_ALIAS`).
+    """
+
+    #: The site to make active by default and when looking up
+    #: a *site_name*. This must identify an object in the root
+    #: of the database that provides :class:`~.IMainApplicationFolder`.
+    main_application_folder_name = hostpolicy.DEFAULT_MAIN_ALIAS
+
+    def __init__(self, db=None, site_name=None):
+        """
+        :param db: See :class:`nti.testing.zodb.mock_db_trans`
+        :keyword str site_name: The name of a site to be made current
+            during execution of the body.
+            The site is found using :func:`~.get_site_for_site_names`
+            while :attr:`main_application_folder_name` is the current site.
+            If not given, the site found at :attr:`main_application_folder_name`
+            will be the current site.
+        """
+        super(current_db_site_trans, self).__init__(db)
+        self._site_cm = None
+        self._site_name = site_name
+
+    def on_application_and_sites_installed(self, folder):
+        """
+        Called when the main application and sites have been installed. This
+        may not be called every time an instance of this class is used, as
+        the database may be persistent.
+        """
+        assert_that(folder, provides(IMainApplicationFolder))
+
+    def on_main_application_folder_missing(self, conn):
+        """
+        Called from :meth:`on_connection_opened` when the :attr:`main_application_folder_name`
+        is not found in the root of the *conn*.
+
+        This method calls :func:`~.install_main_application_and_sites`, passing
+        :attr:`main_application_folder_name` as the *main_alias*.
+        """
+        install_main_application_and_sites(conn,
+                                           main_alias=self.main_application_folder_name,
+                                           main_setup=self.on_application_and_sites_installed)
+
+    def on_connection_opened(self, conn):
+        super(current_db_site_trans, self).on_connection_opened(conn)
+        main_name = hostpolicy.text_type(self.main_application_folder_name)
+
+        root = conn.root()
+        if main_name not in root:
+            self.on_main_application_folder_missing(conn)
+
+        sitemanc = conn.root()[hostpolicy.text_type(self.main_application_folder_name)]
+        if self._site_name:
+            with currentSite(sitemanc):
+                sitemanc = get_site_for_site_names((self._site_name,))
+
+        self._site_cm = currentSite(sitemanc)
+        self._site_cm.__enter__() # pylint:disable=no-member
+        assert component.getSiteManager() == sitemanc.getSiteManager()
+        return conn
+
+    def __exit__(self, t, v, tb):
+        result = self._site_cm.__exit__(t, v, tb) # pylint:disable=no-member
+        super(current_db_site_trans, self).__exit__(t, v, tb)
+        return result
+
+
+mock_db_trans = current_db_site_trans # BWC, remove in 2021
+reset_db_caches = zodb.reset_db_caches # BWC, remove in 2021
+
+def _mock_ds_wrapper_for(func, installer_factory, installer_kwargs, db_factory,
+                         marker=object()):
+
+    @functools.wraps(func)
+    def f(*args):
+        # we may not be in a layer that's done this. Note that we don't tear it down though.
+        # This is needed to run ``install_main_application_and_sites``
+        setHooks()
+        db = db_factory()
+
+        old_db = zodb.ZODBLayer.db
+        old_func_db = marker
+        try:
+            zodb.ZODBLayer.db = db
+            if SharedConfiguringTestLayer.current_test is not None:
+                SharedConfiguringTestLayer.current_test.db = db
+            if args and isinstance(args[0], unittest.TestCase):
+                # self
+                old_func_db = getattr(args[0], 'db', marker)
+                args[0].db = db
+
+            with installer_factory(db, **installer_kwargs):
+                pass
+
+            sitemanc = SiteManagerContainer()
+            sitemanc.setSiteManager(BTreeLocalSiteManager(None))
+
+            with currentSite(sitemanc):
+                assert component.getSiteManager() == sitemanc.getSiteManager()
+                func(*args)
+        finally:
+            if args and isinstance(args[0], unittest.TestCase):
+                if old_func_db is marker:
+                    del args[0].db
+                else:
+                    args[0].db = old_func_db
+            db.close()
+            zodb.ZODBLayer.db = old_db
+    return f
+
+
+def default_db_factory():
+    return ZODB.DB(DemoStorage(name='Users'))
+
+def uses_independent_db_site(*args, **kwargs):
+    """
+    uses_independent_db_site(db_factory=None, installer_factory=current_db_site_trans, installer_kwargs={}) -> function
+
+    A decorator or decorator factory. Creates a new database using *db_factory*,
+    initializes it using *installer_factory*, and then runs the body of the function
+    in a site and site manager that are disconnected from the database.
+
+    If the function is a unittest method, the unittest object's ``db`` attribute
+    will be set to the created db during executing. Likewise, the :class:`nti.testing.zodb.ZODBLayer`
+    ``db`` attribute (and layers that extend from it like :class:`SharedConfiguringTestLayer`)
+    will be set to this object and returned to the previous value on exit.
+
+    This can be called as given in the signature, or can be called with no arguments::
+
+        class MyTest(TestCase):
+
+            @uses_independent_db_site
+            def test_something(self):
+                pass
+
+            @uses_independent_db_site(installer_factory=MyCustomFactory)
+            def test_something_else(self):
+                pass
+
+    The body of the function is free to use :class:`current_db_site_trans` statements.
+    They will default to using the database established here instead of
+    a database established by a test layer (which should be the same in most cases).
+
+    :keyword callable db_factory: The 0-argument factory used to create a DB to pass
+       to the installer.
+
+    :keyword type installer_factory: The factory used to create
+       the installer. The installer executes before the body of the wrapped
+       function. This defaults to :class:`current_db_site_trans`, but can be
+       set to any custom subclass that accepts the db as its first argument and
+       is a context manager that does whatever installation is needed and commits
+       the transaction.
+
+    :keyword dict installer_kwargs: Keyword arguments to pass to the *installer_factory*
+    """
+    assert bool(args) ^ bool(kwargs), "Cannot mix keyword arguments and regular arguments."
+
+    installer_factory = kwargs.pop('installer_factory', current_db_site_trans)
+    installer_kwargs = kwargs.pop('installer_kwargs', {})
+    db_factory = kwargs.pop('db_factory', default_db_factory)
+    assert not kwargs
+    assert len(args) == 1 or not args
+
+    func_factory = lambda func: _mock_ds_wrapper_for(func,
+                                                     installer_factory,
+                                                     installer_kwargs,
+                                                     db_factory)
+    if len(args) == 1:
+        # Being used as a plain decorator
+        return func_factory(args[0])
+    return func_factory
+
+
+class SharedConfiguringTestLayer(zodb.ZODBLayer,
+                                 GCLayerMixin,
+                                 ConfiguringLayerMixin):
+    """
+    A test layer that configures this package, and sets other useful
+    test settings.
+
+    Note that the details of the test settings may change. In this version,
+    this configures the :class:`~.BTreeLocalAdapterRegistry` to immediately
+    switch to BTrees instead of dicts.
+    """
+
+    set_up_packages = ('nti.site',)
+
+    #: The test (a :class:`unittest.TestCase` subclass) currently
+    #: executing in this layer. If there is no such test, this is `None`.
+    current_test = None
+
+    @classmethod
+    def setUp(cls):
+        setHooks()
+        cls.setUpPackages()
+        # Force all the thresholds low so that we do as much testing as possible
+        # with btrees.
+        from .site import BTreeLocalAdapterRegistry
+        from .folder import HostPolicySiteManager
+        assert hasattr(HostPolicySiteManager, 'btree_threshold')
+        HostPolicySiteManager.btree_threshold = 0
+        assert hasattr(BTreeLocalAdapterRegistry, 'btree_provided_threshold')
+        assert hasattr(BTreeLocalAdapterRegistry, 'btree_map_threshold')
+        cls._orig_provided = BTreeLocalAdapterRegistry.btree_provided_threshold
+        cls._orig_map = BTreeLocalAdapterRegistry.btree_map_threshold
+        BTreeLocalAdapterRegistry.btree_provided_threshold = 0
+        BTreeLocalAdapterRegistry.btree_map_threshold = 0
+
+    @classmethod
+    def tearDown(cls):
+        from .site import BTreeLocalAdapterRegistry
+        from .folder import HostPolicySiteManager
+        del HostPolicySiteManager.btree_threshold
+        assert hasattr(HostPolicySiteManager, 'btree_threshold')
+        BTreeLocalAdapterRegistry.btree_provided_threshold = cls._orig_provided
+        BTreeLocalAdapterRegistry.btree_map_threshold = cls._orig_map
+        cls.tearDownPackages()
+        zope.testing.cleanup.cleanUp()
+
+    @classmethod
+    def testSetUp(cls, test=None): # pylint:disable=arguments-differ
+        """
+        Tests that run in this layer have their ``db`` property set to the
+        current ``db`` of this layer.
+        """
+        setHooks()
+        cls.current_test = test = test or find_test()
+        test.db = cls.db
+
+    @classmethod
+    def testTearDown(cls):
+        """
+        When a test in this layer is torn down, its ``db`` property is set
+        to ``None``, as is this layer's :attr:`current_test`.
+        """
+        cls.current_test.db = None
+        cls.current_test = None
+
+
+
+class SiteTestCase(unittest.TestCase):
+    """
+    A test case that runs in the :class:`SharedConfiguringTestLayer`.
+    """
+    layer = SharedConfiguringTestLayer

--- a/src/nti/site/tests/__init__.py
+++ b/src/nti/site/tests/__init__.py
@@ -1,169 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from __future__ import print_function, unicode_literals, absolute_import, division
+from __future__ import print_function, absolute_import, division
 
 __docformat__ = "restructuredtext en"
 
-import unittest
-import functools
-
-import transaction
-
-from ZODB.DemoStorage import DemoStorage
-from hamcrest import assert_that
-
 from nti.testing import zodb
-from nti.testing.layers import ConfiguringLayerMixin
-from nti.testing.layers import GCLayerMixin
-from nti.testing.layers import find_test
-from nti.testing.matchers import provides
 
-from zope import component
-from zope.component.hooks import setHooks
-from zope.component.hooks import site as currentSite
-from zope.site import SiteManagerContainer
-import ZODB
-import zope.testing.cleanup
+from .. import testing
 
 
-from ..hostpolicy import install_main_application_and_sites
-from ..interfaces import IMainApplicationFolder
-from ..site import BTreeLocalSiteManager
-from ..site import get_site_for_site_names
-
-
-root_name = u'nti.dataserver'
-
-def install_main(conn):
-    def setup(f):
-        assert_that(f, provides(IMainApplicationFolder))
-    install_main_application_and_sites(conn,
-                                       root_alias=root_name,
-                                       main_name=u'dataserver2',
-                                       main_setup=setup)
-
-def init_db(db, conn=None):
-    conn = db.open() if conn is None else conn
-    install_main(conn)
-    return conn
-
-class current_db_site_trans(zodb.mock_db_trans):
-
-    def __init__(self, db=None, site_name=None):
-        super(current_db_site_trans, self).__init__(db)
-        self._site_cm = None
-        self._site_name = site_name
-
-    def on_connection_opened(self, conn):
-        super(current_db_site_trans, self).on_connection_opened(conn)
-
-        root = conn.root()
-        if root_name not in root:
-            install_main(conn)
-
-        sitemanc = conn.root()[root_name]
-        if self._site_name:
-            with currentSite(sitemanc):
-                sitemanc = get_site_for_site_names((self._site_name,))
-
-        self._site_cm = currentSite(sitemanc)
-        self._site_cm.__enter__() # pylint:disable=no-member
-        assert component.getSiteManager() == sitemanc.getSiteManager()
-        return conn
-
-    def __exit__(self, t, v, tb):
-        result = self._site_cm.__exit__(t, v, tb) # pylint:disable=no-member
-        super(current_db_site_trans, self).__exit__(t, v, tb)
-        return result
-
-
+current_db_site_trans = testing.current_db_site_trans # BWC, remove in 2021
 mock_db_trans = current_db_site_trans # BWC, remove in 2021
 reset_db_caches = zodb.reset_db_caches # BWC, remove in 2021
-
-def _mock_ds_wrapper_for(func, db):
-
-    @functools.wraps(func)
-    def f(*args):
-        old_db = zodb.ZODBLayer.db
-        try:
-            zodb.ZODBLayer.db = db
-            if SharedConfiguringTestLayer.current_test is not None:
-                SharedConfiguringTestLayer.current_test.db = db
-            # We created the DB fresh, so we know we will have to
-            # open a transaction to be able to set it up.
-            transaction.begin()
-            init_db(db)
-            transaction.commit()
-
-            sitemanc = SiteManagerContainer()
-            sitemanc.setSiteManager(BTreeLocalSiteManager(None))
-
-            with currentSite(sitemanc):
-                assert component.getSiteManager() == sitemanc.getSiteManager()
-                func(*args)
-        finally:
-            db.close()
-            zodb.ZODBLayer.db = old_db
-    return f
-
-def WithMockDS(*args, **kwargs):
-    db = ZODB.DB(DemoStorage(name='Users'))
-    if len(args) == 1 and not kwargs:
-        # Being used as a plain decorator
-        func = args[0]
-        return _mock_ds_wrapper_for(func, db)
-    return lambda func: _mock_ds_wrapper_for(func, db)
-
-
-class SharedConfiguringTestLayer(zodb.ZODBLayer,
-                                 GCLayerMixin,
-                                 ConfiguringLayerMixin):
-
-    set_up_packages = ('nti.site',)
-
-    current_test = None
-
-    @classmethod
-    def setUp(cls):
-        setHooks()
-        cls.setUpPackages()
-        # Force all the thresholds low so that we do as much testing as possible
-        # with btrees.
-        from ..site import BTreeLocalAdapterRegistry
-        from ..folder import HostPolicySiteManager
-        assert hasattr(HostPolicySiteManager, 'btree_threshold')
-        HostPolicySiteManager.btree_threshold = 0
-        assert hasattr(BTreeLocalAdapterRegistry, 'btree_provided_threshold')
-        assert hasattr(BTreeLocalAdapterRegistry, 'btree_map_threshold')
-        cls._orig_provided = BTreeLocalAdapterRegistry.btree_provided_threshold
-        cls._orig_map = BTreeLocalAdapterRegistry.btree_map_threshold
-        BTreeLocalAdapterRegistry.btree_provided_threshold = 0
-        BTreeLocalAdapterRegistry.btree_map_threshold = 0
-
-    @classmethod
-    def tearDown(cls):
-        from ..site import BTreeLocalAdapterRegistry
-        from ..folder import HostPolicySiteManager
-        del HostPolicySiteManager.btree_threshold
-        assert hasattr(HostPolicySiteManager, 'btree_threshold')
-        BTreeLocalAdapterRegistry.btree_provided_threshold = cls._orig_provided
-        BTreeLocalAdapterRegistry.btree_map_threshold = cls._orig_map
-        cls.tearDownPackages()
-        zope.testing.cleanup.cleanUp()
-
-    @classmethod
-    def testSetUp(cls, test=None): # pylint:disable=arguments-differ
-        setHooks()
-        cls.current_test = test = test or find_test()
-        test.db = cls.db
-
-    @classmethod
-    def testTearDown(cls):
-        cls.current_test.db = None
-        cls.current_test = None
-
-
-
-class SiteTestCase(unittest.TestCase):
-    layer = SharedConfiguringTestLayer
+WithMockDS = testing.uses_independent_db_site # BWC, remove in 2021
+SharedConfiguringTestLayer = testing.SharedConfiguringTestLayer # BWC, remove in 2021
+SiteTestCase = testing.SiteTestCase # BWC, remove in 2021

--- a/src/nti/site/tests/__init__.py
+++ b/src/nti/site/tests/__init__.py
@@ -10,7 +10,7 @@ from nti.testing import zodb
 from .. import testing
 
 
-current_db_site_trans = testing.current_db_site_trans # BWC, remove in 2021
+current_db_site_trans = testing.persistent_site_trans # BWC, remove in 2021
 mock_db_trans = current_db_site_trans # BWC, remove in 2021
 reset_db_caches = zodb.reset_db_caches # BWC, remove in 2021
 WithMockDS = testing.uses_independent_db_site # BWC, remove in 2021

--- a/src/nti/site/tests/test_site.py
+++ b/src/nti/site/tests/test_site.py
@@ -184,8 +184,12 @@ class TestGetSiteForSiteNames(AbstractTestBase):
         trivial_site = PersistentTrivialSite(host_sm)
         fake_find.is_callable().returns(pers_comps)
 
-
-        x = get_site_for_site_names(('',), trivial_site)
+        from zope.interface.ro import C3
+        C3.STRICT_IRO = False
+        try:
+            x = get_site_for_site_names(('',), trivial_site)
+        finally:
+            C3.STRICT_IRO = C3.ORIG_STRICT_IRO
 
         assert_that(x, is_not(Persistent))
         assert_that(x, is_(TrivialSite))

--- a/src/nti/site/tests/test_sync.py
+++ b/src/nti/site/tests/test_sync.py
@@ -50,7 +50,7 @@ from nti.site.tests import SharedConfiguringTestLayer
 
 from nti.testing.matchers import validly_provides
 
-class IMock(Interface):
+class IMock(Interface): # pylint:disable=inherit-non-class,too-many-ancestors
     pass
 
 @interface.implementer(IMock)
@@ -68,7 +68,7 @@ from zope.component import globalSiteManager as BASE
 
 from z3c.baseregistry.baseregistry import BaseComponents
 
-class IFoo(Interface):
+class IFoo(Interface): # pylint:disable=inherit-non-class,too-many-ancestors
     pass
 
 class TestSiteSubscriber(unittest.TestCase):
@@ -99,17 +99,17 @@ class TestSiteSubscriber(unittest.TestCase):
         # It should have the marker property
         assert_that(cur_site.getSiteManager(),
                     has_property('host_components',
-                                   host_comps))
+                                 host_comps))
 
         assert_that(ro.ro(cur_site.getSiteManager()),
                     contains(
-                         # The first entry is synthesized
-                         has_property('__name__', new_comps.__name__),
-                         pers_comps,
-                         # The host comps appear after all the bases
-                         # in the ro of the new site
-                         host_comps,
-                         BASE))
+                        # The first entry is synthesized
+                        has_property('__name__', new_comps.__name__),
+                        pers_comps,
+                        # The host comps appear after all the bases
+                        # in the ro of the new site
+                        host_comps,
+                        BASE))
 
     def testTraverseFailsIntoSiblingSiteExceptHostPolicyFolders(self):
         new_comps = BaseComponents(BASE, 'sub_site', ())
@@ -169,7 +169,7 @@ DEMOALPHA = BaseComponents(DEMO,
 _SITES = (EVAL, EVALALPHA, DEMO, DEMOALPHA)
 
 from zope.component.interfaces import ISite
-from zope.component.interfaces import IComponents
+from zope.interface.interfaces import IComponents
 
 from zope.site.interfaces import INewLocalSite
 
@@ -187,7 +187,7 @@ from nti.site.testing import persistent_site_trans as mock_db_trans
 
 from nti.testing.matchers import verifiably_provides
 
-class ITestSiteSync(interface.Interface):
+class ITestSiteSync(interface.Interface): # pylint:disable=inherit-non-class,too-many-ancestors
     pass
 
 @interface.implementer(ITestSiteSync)
@@ -243,22 +243,22 @@ class TestSiteSync(unittest.TestCase):
         class S2(Base): pass
         # DB sites
         class PS1(S1, DS): pass
-        class PS2(S2, PS1): pass
+        class PS2(S2, PS1): pass # pylint:disable=too-many-ancestors
 
         assert_that(ro.ro(PS2),
-                     is_([PS2, S2, PS1, S1, Base, DS, Root, GSM, object]))
+                    is_([PS2, S2, PS1, S1, Base, DS, Root, GSM, object]))
 
     @WithMockDS
     def test_site_sync(self):
 
         for site in _SITES:
             assert_that(_find_site_components((site.__name__,)),
-                         is_(not_none()))
+                        is_(not_none()))
 
         with mock_db_trans() as conn:
             for site in _SITES:
                 assert_that(_find_site_components((site.__name__,)),
-                             is_(not_none()))
+                            is_(not_none()))
 
 
             ds = conn.root()['nti.dataserver']
@@ -284,7 +284,7 @@ class TestSiteSync(unittest.TestCase):
         with mock_db_trans() as conn:
             for site in _SITES:
                 assert_that(_find_site_components((site.__name__,)),
-                             is_(not_none()))
+                            is_(not_none()))
 
             ds = conn.root()['nti.dataserver']
 
@@ -297,7 +297,7 @@ class TestSiteSync(unittest.TestCase):
             # If we ask the demoalpha persistent site for an ITestSyteSync,
             # it will find us, because it goes to the demo global site
             assert_that(sites[DEMOALPHA.__name__].getSiteManager().queryUtility(ITestSiteSync),
-                         is_(ASync))
+                        is_(ASync))
 
             # However, if we put something in the demo *persistent* site, it
             # will find that
@@ -343,7 +343,7 @@ class TestSiteSync(unittest.TestCase):
 
             # And that it's what we get back if we ask for it
             assert_that(get_site_for_site_names((DEMOALPHA.__name__,)),
-                         is_(same_instance(sites[DEMOALPHA.__name__])))
+                        is_(same_instance(sites[DEMOALPHA.__name__])))
 
         # No new sites created
         assert_that(self._events, has_length(len(_SITES)))

--- a/src/nti/site/tests/test_sync.py
+++ b/src/nti/site/tests/test_sync.py
@@ -182,8 +182,8 @@ from nti.site.hostpolicy import get_host_site
 from nti.site.site import _find_site_components
 from nti.site.site import get_site_for_site_names
 
-from nti.site.tests import WithMockDS
-from nti.site.tests import mock_db_trans
+from nti.site.testing import uses_independent_db_site as WithMockDS
+from nti.site.testing import persistent_site_trans as mock_db_trans
 
 from nti.testing.matchers import verifiably_provides
 

--- a/src/nti/site/tests/test_testing.py
+++ b/src/nti/site/tests/test_testing.py
@@ -30,7 +30,7 @@ class TestPrintTree(unittest.TestCase):
     def test_print_tree(self):
         buf = self.NativeIO()
 
-        class Trans(testing.current_db_site_trans):
+        class Trans(testing.persistent_site_trans):
 
             def on_application_and_sites_installed(self, folder):
                 super(Trans, self).on_application_and_sites_installed(folder)
@@ -59,7 +59,7 @@ class TestPrintTree(unittest.TestCase):
 class TestCurrentDBSiteTrans(testing.SiteTestCase):
 
     def test_find_site(self):
-        with testing.current_db_site_trans(site_name='foobar'):
+        with testing.persistent_site_trans(site_name='foobar'):
             pass
 
 class TestIndependent(unittest.TestCase):

--- a/src/nti/site/tests/test_testing.py
+++ b/src/nti/site/tests/test_testing.py
@@ -1,0 +1,73 @@
+# -*- coding: utf-8 -*-
+"""
+Tests for nti.site.tests.testing.
+
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import unittest
+
+from nti.site import testing
+
+class TestPrintTree(unittest.TestCase):
+
+    def setUp(self):
+        super(TestPrintTree, self).setUp()
+        testing.setHooks()
+
+    def tearDown(self):
+        testing.resetHooks()
+        super(TestPrintTree, self).tearDown()
+    if bytes is str:
+        # Python 2. Use something that automatically encodes unicode
+        # and also accepts bytes.
+        from cStringIO import StringIO as NativeIO
+    else:
+        from io import StringIO as NativeIO
+
+    def test_print_tree(self):
+        buf = self.NativeIO()
+
+        class Trans(testing.current_db_site_trans):
+
+            def on_application_and_sites_installed(self, folder):
+                super(Trans, self).on_application_and_sites_installed(folder)
+                folder._p_jar.root()['key'] = 'value'
+                testing.print_tree(folder._p_jar.root(), file=buf)
+
+
+        # open for the side-effects
+        with Trans(testing.default_db_factory()):
+            pass
+
+        printed = buf.getvalue()
+        self.assertIn('<Connection Root Dictionary>', printed)
+        self.assertIn('<ISite,IRootFolder>: Application', printed)
+        self.assertIn('<ISite,IMainApplicationFolder>: dataserver2', printed)
+        self.assertIn('dataserver2 -> dataserver2', printed)
+        self.assertIn('nti.dataserver -> dataserver2', printed)
+        self.assertIn('nti.dataserver_root -> Application', printed)
+
+    def test_print_basic(self):
+        buf = self.NativeIO()
+        testing.print_tree('a string', file=buf)
+        printed = buf.getvalue()
+        self.assertIn('a string', printed)
+
+class TestCurrentDBSiteTrans(testing.SiteTestCase):
+
+    def test_find_site(self):
+        with testing.current_db_site_trans(site_name='foobar'):
+            pass
+
+class TestIndependent(unittest.TestCase):
+
+    @testing.uses_independent_db_site
+    def test_sets_db_no_layer(self):
+        self.assertTrue(hasattr(self, 'db'))
+
+    @testing.uses_independent_db_site(installer_kwargs={'site_name': None})
+    def test_keyword_argument(self):
+        pass

--- a/src/nti/site/utils.py
+++ b/src/nti/site/utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 """
-.. $Id$
+This module currently has no non-deprecated functions.
 """
 
 from __future__ import print_function, absolute_import, division

--- a/tox.ini
+++ b/tox.ini
@@ -1,29 +1,33 @@
 [tox]
-envlist = pypy, py27, py34, py35, py36, docs
+envlist = pypy,py27,py35,py36,py37,py38,pypy3,coverage,docs
 
 [testenv]
-deps =
-	 .[test]
-
+# JAM: The comment and setting are cargo-culted from zope.interface.
+# ``usedevelop`` is required otherwise unittest complains that it
+# discovers a file in src/... but imports it from .tox/.../
+# ``skip_install`` also basically works, but that causes the ``extras``
+# not to be installed (though ``deps`` still are), and doesn't
+# rebuild C extensions.
+usedevelop = true
+extras = test
 commands =
-         zope-testrunner --test-path=src  --auto-color --auto-progress [] # substitute with tox positional args
-
-[testenv:docs]
-basepython =
-    python2.7
-commands =
-    sphinx-build -b html -d doc/_build/doctrees doc doc/_build/html
-deps =
-    {[testenv]deps}
-    .[docs]
+    coverage run -p -m zope.testrunner --test-path=src  --auto-color --auto-progress [] # substitute with tox positional args
+setenv =
+    PYTHONHASHSEED=1042466059
+    ZOPE_INTERFACE_STRICT_IRO=1
 
 [testenv:coverage]
-usedevelop = true
-basepython =
-    python3.6
+# The -i/--ignore arg may be necessary, I'm not sure.
+# It was cargo-culted over from zope.interface.
 commands =
-    coverage run -m zope.testrunner --test-path=src []
-    coverage report --fail-under=100
-deps =
-    {[testenv]deps}
-    coverage
+    coverage combine
+    coverage report -i
+    coverage html -i
+    coverage xml -i
+depends = py27,py36,py37,py38,pypy,pypy3,docs
+parallel_show_output = true
+
+[testenv:docs]
+extras = docs
+commands =
+    sphinx-build -b html -d doc/_build/doctrees doc doc/_build/html


### PR DESCRIPTION
I wish I had a better name for `current_db_site_trans`; it's better than 'mock_db_trans' since this version actually sets up a site, but it's still not great. Thoughts?

Also a minor change to install_main_appliaction_and_sites.