### PR TITLE
Fix a TypeError during BTree conversion.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@
 2.4.1 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix a ``TypeError`` in logging during the conversion performed by
+  ``BTreePersistentComponents``.
 
 
 2.4.0 (2021-02-25)

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ TESTS_REQUIRE = [
     'z3c.baseregistry',
     'zope.testrunner',
     'coverage',
+    'zope.testing',
 ]
 
 

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -293,7 +293,7 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
                 # _subscribers always becomes a BTree, because its payload is stashed
                 # away in immutable tuples
                 logger.info("Converting ordered mapping (name=%s len=%d) to %s.",
-                            len(mapping), btree_type)
+                            name, len(mapping), btree_type)
                 mapping = btree_type(mapping)
                 byorder[i] = mapping
                 # self._adapters and self._subscribers are both simply

--- a/src/nti/site/tests/test_site.py
+++ b/src/nti/site/tests/test_site.py
@@ -619,7 +619,12 @@ class TestBTreeSiteMan(AbstractTestBase):
     def test_convert_many_named_utilities_one_interface(self):
         # Testing the default thresholds. We're registering a bunch of
         # utilities for a single interface.
+        from zope.testing.loggingsupport import InstalledHandler
         from persistent.mapping import PersistentMapping
+
+        log = InstalledHandler('nti.site.site')
+        self.addCleanup(log.uninstall)
+
         comps = BLSM(None)
         assert comps.btree_threshold > 0
         assert comps.utilities.btree_map_threshold > 0
@@ -678,6 +683,9 @@ class TestBTreeSiteMan(AbstractTestBase):
         comps.unregisterUtility(comps.getUtility(IFoo))
         assert_that(comps.queryUtility(IFoo), is_(none()))
 
+        logs = str(log)
+        self.assertIn('Converting ordered mapping', logs)
+        self.assertIn('Converting bucket', logs)
 
     def test_convert_many_utilities_many_interfaces(self):
         # Testing the default thresholds. We're registering a bunch of


### PR DESCRIPTION
Caused by incorrect log arguments. Only seed of that level of logging was enabled.

Add tests for this.