### PR TITLE
Swap only on write

### DIFF
--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -441,6 +441,7 @@ class BTreeLocalSiteManager(BTreePersistentComponents, LocalSiteManager):
                 # Pure-python doesn't set _p_changed, but C does.
                 changed = reg._p_changed
                 reg.__class__ = BTreeLocalAdapterRegistry
+                reg._v_setting_state = False
                 if not changed:
                     reg._p_changed = False
 

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -402,20 +402,12 @@ class BTreePersistentComponents(PersistentComponents):
             # *is*. That's why __setstate__ is there and not here...it doesn't make much sense here.
 
     def registerUtility(self, *args, **kwargs):  # pylint:disable=arguments-differ
-        try:
-            self.utilities._v_setting_state = False
-            result = super(BTreePersistentComponents, self).registerUtility(*args, **kwargs)
-        finally:
-            self.utilities._v_setting_state = True
+        result = super(BTreePersistentComponents, self).registerUtility(*args, **kwargs)
         self._check_and_btree_map('_utility_registrations')
         return result
 
     def registerAdapter(self, *args, **kwargs): # pylint:disable=arguments-differ
-        try:
-            self.adapters._v_setting_state = False
-            result = super(BTreePersistentComponents, self).registerAdapter(*args, **kwargs)
-        finally:
-            self.adapters._v_setting_state = True
+        result = super(BTreePersistentComponents, self).registerAdapter(*args, **kwargs)
         self._check_and_btree_map('_adapter_registrations')
         return result
 


### PR DESCRIPTION
This PR prevents our BTreePersistentComponents from restructure the internals when loading from the db. Fixes #38 

