### PR TITLE
Full recurse and convert all dicts beneath a BTree to a BTree

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,9 @@
 2.4.3 (unreleased)
 ==================
 
-- Nothing changed yet.
+- Fix ``BTreePersistentComponents`` leaving some nested dicts alone
+  when they should be converted to BTrees. This could cause data loss.
+  See :issue:`41`.
 
 
 2.4.2 (2021-03-01)

--- a/src/nti/site/site.py
+++ b/src/nti/site/site.py
@@ -434,7 +434,7 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
         order = len(required)
         byorder = self._subscribers
         if order >= len(byorder):
-            return False
+            return False # pragma: no cover
 
         components = byorder[order]
         key = required + (provided,)
@@ -442,7 +442,7 @@ class BTreeLocalAdapterRegistry(_LocalAdapterRegistry):
         for k in key:
             d = components.get(k)
             if d is None:
-                return False
+                return False # pragma: no cover
             components = d
 
         sub_vals = components.get(name, ())


### PR DESCRIPTION
This solves the `_p_changed` issue and fixes #41 

In practice, this will be slightly slower for mutating large utility registrations, but probably not by much (I haven't tried to measure).